### PR TITLE
Fixes ohai install error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN echo 'webserver:qweqwe'|chpasswd
 # chef version is given in tugger 'lib/tugger-container-init/provision' and in tugger-stack 'Dockerfile'
 RUN curl -L https://www.chef.io/chef/install.sh | bash -s -- -v 12.21.1
 RUN echo "gem: --no-ri --no-rdoc" > ~/.gemrc
-RUN /opt/chef/embedded/bin/gem install berkshelf
+RUN /opt/chef/embedded/bin/gem install berkshelf -v 6.3.2


### PR DESCRIPTION
"ohai requires Ruby version >= 2.4"
Pinning berkshelf fixed that issue.

Probably related to this.
https://github.com/berkshelf/berkshelf/issues/1755